### PR TITLE
fix: catch exception in computed

### DIFF
--- a/.changeset/chilled-rivers-double.md
+++ b/.changeset/chilled-rivers-double.md
@@ -1,0 +1,5 @@
+---
+'ccstate': minor
+---
+
+fix: capture exception in computed process

--- a/packages/ccstate/src/core/__tests__/ccstate.test.ts
+++ b/packages/ccstate/src/core/__tests__/ccstate.test.ts
@@ -28,7 +28,6 @@ test('computed value should work', () => {
       debugLabel: 'derived',
     },
   );
-
   expect(store.get(derived)).toBe(2);
 });
 

--- a/packages/ccstate/src/core/signal/signal.ts
+++ b/packages/ccstate/src/core/signal/signal.ts
@@ -1,4 +1,4 @@
-import type { Signal } from '../../../types/core/signal';
+import type { Computed, Signal } from '../../../types/core/signal';
 import type { StoreContext } from '../../../types/core/store';
 
 export function currentValue<T>(signal: Signal<T>, context: StoreContext): T | undefined {
@@ -7,4 +7,17 @@ export function currentValue<T>(signal: Signal<T>, context: StoreContext): T | u
 
 export function shouldDistinct<T>(signal: Signal<T>, value: T, context: StoreContext) {
   return currentValue(signal, context) === value;
+}
+
+export function shouldDistinctError(signal: Computed<unknown>, context: StoreContext) {
+  const currentState = context.stateMap.get(signal);
+  if (!currentState) {
+    return false;
+  }
+
+  if ('error' in currentState && currentState.error !== undefined) {
+    return true;
+  }
+
+  return false;
 }

--- a/packages/ccstate/src/core/store/store.ts
+++ b/packages/ccstate/src/core/store/store.ts
@@ -81,7 +81,12 @@ function sub<T>(
 const get: StoreGet = (signal, context, mutation) => {
   return withGetInterceptor(
     () => {
-      return readSignal(signal, context, mutation).val;
+      const signalState = readSignal(signal, context, mutation);
+      if ('error' in signalState) {
+        throw signalState.error as Error;
+      }
+
+      return signalState.val;
     },
     signal,
     context.interceptor?.get,

--- a/packages/ccstate/src/core/store/sub.ts
+++ b/packages/ccstate/src/core/store/sub.ts
@@ -129,6 +129,7 @@ export function subSingleSignal<T>(
 
 export function notify(context: StoreContext, mutation: Mutation) {
   const pendingListeners = mutation.pendingListeners;
+
   mutation.pendingListeners = new Set();
 
   for (const listener of pendingListeners) {

--- a/packages/ccstate/types/core/store.ts
+++ b/packages/ccstate/types/core/store.ts
@@ -67,13 +67,23 @@ export interface StateState<T> {
   epoch: number;
 }
 
-export interface ComputedState<T> {
-  mounted?: Mounted;
-  val: T;
-  dependencies: Map<Signal<unknown>, number>;
-  epoch: number;
-  abortController?: AbortController;
-}
+export type ComputedState<T> =
+  | {
+      mounted?: Mounted;
+      val: T;
+      error: undefined;
+      dependencies: Map<Signal<unknown>, number>;
+      epoch: number;
+      abortController?: AbortController;
+    }
+  | {
+      mounted?: Mounted;
+      val: undefined;
+      error: unknown;
+      dependencies: Map<Signal<unknown>, number>;
+      epoch: number;
+      abortController?: AbortController;
+    };
 
 export type SignalState<T> = StateState<T> | ComputedState<T>;
 export type StateMap = WeakMap<Signal<unknown>, SignalState<unknown>>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
         version: 2.1.8(@types/node@22.9.1)(playwright@1.49.0)(typescript@5.7.2)(vite@5.4.11(@types/node@22.9.1)(terser@5.37.0))(vitest@2.1.8)
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(@vitest/browser@2.1.8)(vitest@2.1.8)
+        version: 2.1.8(@vitest/browser@2.1.8(@types/node@22.9.1)(playwright@1.49.0)(typescript@5.7.2)(vite@5.4.11(@types/node@22.9.1)(terser@5.37.0))(vitest@2.1.8))(vitest@2.1.8(@types/node@22.9.1)(@vitest/browser@2.1.8)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@25.0.1)(msw@2.6.6(@types/node@22.9.1)(typescript@5.7.2))(terser@5.37.0))
       '@vitest/ui':
         specifier: 2.1.8
         version: 2.1.8(vitest@2.1.8)
@@ -45,7 +45,7 @@ importers:
         version: 5.2.1(eslint-config-prettier@9.1.0(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))(prettier@3.4.2)
       eslint-plugin-vitest:
         specifier: ^0.5.4
-        version: 0.5.4(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2)(vitest@2.1.8)
+        version: 0.5.4(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2)(vitest@2.1.8(@types/node@22.9.1)(@vitest/browser@2.1.8)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@25.0.1)(msw@2.6.6(@types/node@22.9.1)(typescript@5.7.2))(terser@5.37.0))
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -383,7 +383,7 @@ importers:
         version: 6.6.3
       '@testing-library/svelte':
         specifier: ^5.2.6
-        version: 5.2.6(svelte@5.15.0)(vite@6.0.5(@types/node@22.9.1)(jiti@1.21.6)(terser@5.37.0)(yaml@2.6.1))(vitest@2.1.8)
+        version: 5.2.6(svelte@5.15.0)(vite@6.0.5(@types/node@22.9.1)(jiti@1.21.6)(terser@5.37.0)(yaml@2.6.1))(vitest@2.1.8(@types/node@22.9.1)(@vitest/browser@2.1.8)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@25.0.1)(msw@2.6.6(@types/node@22.9.1)(typescript@5.7.2))(terser@5.37.0))
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.5.2(@testing-library/dom@10.4.0)
@@ -4690,18 +4690,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.18.1:
     resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
     engines: {node: '>=10.0.0'}
@@ -6339,7 +6327,7 @@ snapshots:
       '@types/react': 19.0.2
       '@types/react-dom': 18.3.1
 
-  '@testing-library/svelte@5.2.6(svelte@5.15.0)(vite@6.0.5(@types/node@22.9.1)(jiti@1.21.6)(terser@5.37.0)(yaml@2.6.1))(vitest@2.1.8)':
+  '@testing-library/svelte@5.2.6(svelte@5.15.0)(vite@6.0.5(@types/node@22.9.1)(jiti@1.21.6)(terser@5.37.0)(yaml@2.6.1))(vitest@2.1.8(@types/node@22.9.1)(@vitest/browser@2.1.8)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@25.0.1)(msw@2.6.6(@types/node@22.9.1)(typescript@5.7.2))(terser@5.37.0))':
     dependencies:
       '@testing-library/dom': 10.4.0
       svelte: 5.15.0
@@ -6546,12 +6534,12 @@ snapshots:
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/mocker': 2.1.8(msw@2.6.6(@types/node@22.9.1)(typescript@5.7.2))(vite@5.4.11(@types/node@22.9.1)(terser@5.37.0))
       '@vitest/utils': 2.1.8
-      magic-string: 0.30.13
+      magic-string: 0.30.17
       msw: 2.6.6(@types/node@22.9.1)(typescript@5.7.2)
       sirv: 3.0.0
       tinyrainbow: 1.2.0
       vitest: 2.1.8(@types/node@22.9.1)(@vitest/browser@2.1.8)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@25.0.1)(msw@2.6.6(@types/node@22.9.1)(typescript@5.7.2))(terser@5.37.0)
-      ws: 8.18.0
+      ws: 8.18.1
     optionalDependencies:
       playwright: 1.49.0
     transitivePeerDependencies:
@@ -6561,7 +6549,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@2.1.8(@vitest/browser@2.1.8)(vitest@2.1.8)':
+  '@vitest/coverage-v8@2.1.8(@vitest/browser@2.1.8(@types/node@22.9.1)(playwright@1.49.0)(typescript@5.7.2)(vite@5.4.11(@types/node@22.9.1)(terser@5.37.0))(vitest@2.1.8))(vitest@2.1.8(@types/node@22.9.1)(@vitest/browser@2.1.8)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@25.0.1)(msw@2.6.6(@types/node@22.9.1)(typescript@5.7.2))(terser@5.37.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -7401,7 +7389,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.17.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.17.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -7423,7 +7411,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.16.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.17.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.16.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.17.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.16.0(jiti@1.21.6)))(eslint@9.16.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -7450,7 +7438,7 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 9.1.0(eslint@9.16.0(jiti@1.21.6))
 
-  eslint-plugin-vitest@0.5.4(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2)(vitest@2.1.8):
+  eslint-plugin-vitest@0.5.4(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2)(vitest@2.1.8(@types/node@22.9.1)(@vitest/browser@2.1.8)(@vitest/ui@2.1.8)(happy-dom@15.11.7)(jsdom@25.0.1)(msw@2.6.6(@types/node@22.9.1)(typescript@5.7.2))(terser@5.37.0)):
     dependencies:
       '@typescript-eslint/utils': 7.18.0(eslint@9.16.0(jiti@1.21.6))(typescript@5.7.2)
       eslint: 9.16.0(jiti@1.21.6)
@@ -9430,10 +9418,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.18.0: {}
-
-  ws@8.18.1:
-    optional: true
+  ws@8.18.1: {}
 
   xml-name-validator@5.0.0:
     optional: true


### PR DESCRIPTION
When an exception is thrown during the execution of a computed signal, the computation process of the signals state graph is interrupted. This can disrupt the consistency of other signals.

Following Jotai's behavior
(see https://stackblitz.com/edit/vitejs-vite-i8u9jc24?file=src%2Fjotai.test.ts), when an exception is thrown in a computed signal, record the exception in the computed state and continue the state computation of other signals. This exception will only be thrown when the computed signal is accessed `get`.