### PR TITLE
fix(react): add global error handler for floating promises in useLoad…

### DIFF
--- a/.changeset/smart-chairs-sneeze.md
+++ b/.changeset/smart-chairs-sneeze.md
@@ -1,0 +1,5 @@
+---
+'ccstate-react': minor
+---
+
+fix(react): add global error handler for floating promises in useLoadable

--- a/packages/react/src/useGet.ts
+++ b/packages/react/src/useGet.ts
@@ -3,7 +3,10 @@ import { useStore } from './provider';
 import { command } from 'ccstate';
 import type { Computed, State } from 'ccstate';
 
-export function useGet<T>(atom: State<T> | Computed<T>) {
+export function useGetInternal<T>(
+  atom: State<T> | Computed<T>,
+  { silenceUnhandleRejection }: { silenceUnhandleRejection: boolean },
+) {
   const store = useStore();
   return useSyncExternalStore(
     (fn) => {
@@ -14,7 +17,15 @@ export function useGet<T>(atom: State<T> | Computed<T>) {
       };
     },
     () => {
-      return store.get(atom);
+      const val = store.get(atom);
+      if (val instanceof Promise && silenceUnhandleRejection) {
+        val.catch(() => void 0);
+      }
+      return val;
     },
   );
+}
+
+export function useGet<T>(atom: State<T> | Computed<T>) {
+  return useGetInternal(atom, { silenceUnhandleRejection: false });
 }

--- a/packages/react/src/useLoadable.ts
+++ b/packages/react/src/useLoadable.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useGet } from './useGet';
+import { useGetInternal } from './useGet';
 import type { Computed, State } from 'ccstate';
 
 type Loadable<T> =
@@ -19,7 +19,9 @@ function useLoadableInternal<T>(
   atom: State<Promise<T> | T> | Computed<Promise<T> | T>,
   keepLastResolved: boolean,
 ): Loadable<T> {
-  const promise = useGet(atom);
+  const promise = useGetInternal(atom, {
+    silenceUnhandleRejection: true,
+  });
 
   const [promiseResult, setPromiseResult] = useState<Loadable<T>>({
     state: 'loading',


### PR DESCRIPTION
…able

In certain React scenarios, promises returned by computed atoms may not enter the effect calculation process in useLoadable, resulting in floating promises. Therefore, a global event handler needs to be added for promises obtained by useLoadable to handle unhandled rejections.