### PR TITLE
refactor: rename watcher parameter to watchFn in storeWatch function for clarity

### DIFF
--- a/packages/ccstate/src/core/store/store.ts
+++ b/packages/ccstate/src/core/store/store.ts
@@ -87,7 +87,7 @@ const storeSet: StoreSet = <T, Args extends SetArgs<T, unknown[]>>(
   );
 };
 
-const storeWatch: StoreWatch = (watcher: Watch, context: StoreContext, options?: WatchOptions) => {
+const storeWatch: StoreWatch = (watchFn: Watch, context: StoreContext, options?: WatchOptions) => {
   const computed$ = computed(
     (get, { signal }) => {
       let childSignal: AbortSignal | undefined;
@@ -100,7 +100,7 @@ const storeWatch: StoreWatch = (watcher: Watch, context: StoreContext, options?:
         },
       };
 
-      watcher(get, obOptions);
+      watchFn(get, obOptions);
     },
     {
       debugLabel: options?.debugLabel,

--- a/packages/ccstate/src/core/store/sub.ts
+++ b/packages/ccstate/src/core/store/sub.ts
@@ -39,7 +39,7 @@ function initMount<T>(readSignal: ReadSignal, signal$: Signal<T>, context: Store
 
   const signalState = readSignal(signal$, context, mutation);
 
-  signalState.mounted = signalState.mounted ?? {
+  signalState.mounted = {
     readDepts: new Set(),
   };
 


### PR DESCRIPTION
refactor: simplify mounted state initialization in initMount function